### PR TITLE
Added itemprop to allowed attributes

### DIFF
--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -46,7 +46,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         'sizes',
         'type',
         'title',
-        'extras'
+        'extras',
+        'itemprop'
     ];
 
     /**


### PR DESCRIPTION
Allows to set something like the following. Is needed for setting structured data markup.
[Include Your Site Name in Search Results](https://developers.google.com/structured-data/site-name).

``` php
$this->headLink()->prependAlternate(
    [
        'rel' => 'canonical',
        'itemprop' => 'url',
        'href' => 'https://example.com/'
    ],
    'APPEND'
);
```

```
<link rel="canonical" href="https://example.com/" itemprop="url">
```
